### PR TITLE
Fix autologin refresh

### DIFF
--- a/Backend/Application/Interfaces/AuthService/IAuthService.cs
+++ b/Backend/Application/Interfaces/AuthService/IAuthService.cs
@@ -13,7 +13,7 @@ namespace Backend.Application.Interfaces.AuthService
         Task LogoutAsync(string accessToken, string refreshToken, Guid sessionId, bool logoutAllUsers);
 
         // RefreshToken and check access token
-        Task<AuthStatusResult> CheckAndRefreshAsync(string accessToken, string refreshCookie, Guid sessionId, string userAgent, string deviceId, DbConnection cn, DbTransaction tx);
+        Task<AuthStatusResult> CheckAndRefreshAsync(string? accessToken, string refreshCookie, Guid sessionId, string userAgent, string deviceId, DbConnection cn, DbTransaction tx);
         Task<(string token, Guid tokenId, DateTime exp)> IssueAsync(UserCtx ctx, string jti);
     }
 }


### PR DESCRIPTION
## Summary
- allow `CheckAndRefreshAsync` to work when only a refresh token cookie is present
- make `accessToken` optional in `IAuthService`
- relax sessionId requirement in refresh flow and only blacklist old access token if provided

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*
- `npm test` in `Frontend` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_b_683b17375cc0832fa12c0bfe3dcba0b8